### PR TITLE
Phrase replacement. Use source/destination instead of caller/listener.

### DIFF
--- a/config/srt_exporter.yaml
+++ b/config/srt_exporter.yaml
@@ -35,7 +35,7 @@ global:
 # customized configuration for each srt exporter object
 srt_exporters:
   # srt exporter's name string is the identity for srt exporter to allocate the corresponding configuration
-  - name: sample_srt_caller
+  - name: sample_srt_source
     ip: 0.0.0.0
     # port value here does not have to be within global port range
     # if port is not specified, available port would be selected according to global configuration
@@ -49,7 +49,7 @@ srt_exporters:
     labels:
       - name: role
         value: srt_source
-  - name: sample_srt_listener
+  - name: sample_srt_destination
     ip: 0.0.0.0
     port: 10028
     filter:

--- a/document/design.md
+++ b/document/design.md
@@ -54,7 +54,7 @@ global:
         value: srt_exporter
 
 srt_exporters:
-    - name: sample_srt_caller
+    - name: sample_srt_source
     ip: 127.0.0.1
     port: 10027
     collector_mode: collect_on_request
@@ -64,7 +64,7 @@ srt_exporters:
     labels:
         - name: sample_name_1
         value: sample_value_1
-    - name: sample_srt_listener
+    - name: sample_srt_destination
     ip: 127.0.0.1
     port: 10028
     filter:

--- a/document/tutorial.md
+++ b/document/tutorial.md
@@ -29,7 +29,7 @@ There are several ways to install and run Prometheus server, it is up to user to
 
 ### Build
 
-`sample_srtcaller` and `sample_srtlistener` can be compiled.
+`sample_srtsource` and `sample_srtdestination` can be compiled.
 
 ```bash
 cd srt-prometheus-exporter/sample
@@ -42,34 +42,34 @@ Make sure that current directory is `srt-prometheus-exporter/sample` because tho
 
 ```bash
 cd srt-prometheus-exporter/sample
-./sample_srtcaller
+./sample_srtsource
 ```
 
 A sample of SRT source application.
 
 It creates SRT socket and updates SRT socket information to SRT Exporter library.
-Its SRT Exporter object's name is `sample_srt_caller`.
+Its SRT Exporter object's name is `sample_srt_source`.
 It tries to connect port `8888` with this SRT socket. Once connection is accepted, this application keeps sending packages to the destination each second.
 
 Access `http://127.0.0.1:10027/metrics` from a browser to trigger an http request to it manually.
 
-<img src="./images/sample_srt_source.png" alt="sample_srt_caller" width="400">
+<img src="./images/sample_srt_source.png" alt="sample_srt_source" width="400">
 
 
 ```bash
 cd srt-prometheus-exporter/sample
-./sample_srtlistener
+./sample_srtdestination
 ```
 
 A sample of SRT destination application.
 
 It starts listening to port on `8888` when application started. Once an SRT source wants to connect this port, it accepts the connection and starts receiving packages from this connection.
 The SRT socket of this connection would be updated to SRT exporter once the connection is established. Thus, SRT socket statistic requested from Prometheus can be collected from SRT library.
-Its SRT Exporter object's name is `sample_srt_listener`.
+Its SRT Exporter object's name is `sample_srt_destination`.
 
 Access `http://127.0.0.1:10028/metrics` from a browser to trigger an http request to it manually.
 
-<img src="./images/sample_srt_destination.png" alt="sample_srt_listener" width="400">
+<img src="./images/sample_srt_destination.png" alt="sample_srt_destination" width="400">
 
 ### Start Prometheus
 

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -22,23 +22,23 @@ LIBS = -lsrtexp
 LIBS += -lsrt
 LIBS += -lyaml-cpp
 
-SAMPLE_APP_SRT_CALLER = sample_srtcaller
-SAMPLE_APP_SRT_LISTENER = sample_srtlistener
-SRC_CALLER = sample_srtcaller.c
-SRC_LISTENER = sample_srtlistener.c
+SAMPLE_APP_SRT_SOURCE = sample_srtsource
+SAMPLE_APP_SRT_DESTINATION = sample_srtdestination
+SRC_SOURCE = sample_srtsource.c
+SRC_DESTINATION = sample_srtdestination.c
 
 all: srt
 
-srt: $(SAMPLE_APP_SRT_CALLER) $(SAMPLE_APP_SRT_LISTENER)
+srt: $(SAMPLE_APP_SRT_SOURCE) $(SAMPLE_APP_SRT_DESTINATION)
 
-$(SAMPLE_APP_SRT_CALLER): $(SRC_CALLER)
-	$(CC) -o $@ $(CFLAGS) $(SRC_CALLER) $(LDFLAGS) $(LIBS)
+$(SAMPLE_APP_SRT_SOURCE): $(SRC_SOURCE)
+	$(CC) -o $@ $(CFLAGS) $(SRC_SOURCE) $(LDFLAGS) $(LIBS)
 
-$(SAMPLE_APP_SRT_LISTENER): $(SRC_LISTENER)
-	$(CC) -o $@ $(CFLAGS) $(SRC_LISTENER) $(LDFLAGS) $(LIBS)
+$(SAMPLE_APP_SRT_DESTINATION): $(SRC_DESTINATION)
+	$(CC) -o $@ $(CFLAGS) $(SRC_DESTINATION) $(LDFLAGS) $(LIBS)
 
 clean:
-	-rm $(SAMPLE_APP_SRT_CALLER)
-	-rm $(SAMPLE_APP_SRT_LISTENER)
+	-rm $(SAMPLE_APP_SRT_SOURCE)
+	-rm $(SAMPLE_APP_SRT_DESTINATION)
 
 .PHONY: all srt clean

--- a/sample/sample_srtdestination.c
+++ b/sample/sample_srtdestination.c
@@ -21,7 +21,7 @@
 
 int main() {
     char configFile[32] = "../config/srt_exporter.yaml";
-    char exporterName[32] = "sample_srt_listener";
+    char exporterName[32] = "sample_srt_destination";
     int id = -1;
 
     SRTSOCKET srtsock = SRT_INVALID_SOCK;

--- a/sample/sample_srtsource.c
+++ b/sample/sample_srtsource.c
@@ -21,7 +21,7 @@
 
 int main() {
     char configFile[32] = "../config/srt_exporter.yaml";
-    char exporterName[32] = "sample_srt_caller";
+    char exporterName[32] = "sample_srt_source";
     int id = -1;
 
     SRTSOCKET srtsock = SRT_INVALID_SOCK;
@@ -44,7 +44,7 @@ int main() {
 
         return -1;
     }
-    srtexp_c_label_register("application", "sample_srtcaller", NULL, id);
+    srtexp_c_label_register("application", "sample_srtsource", NULL, id);
     srtexp_c_label_register("importance", "special", "pktSentTotal", id);
     srtexp_c_label_register("importance", "normal", "pktSentTotal", id);
     //srtexp_c_label_register("importance", NULL, "pktSentTotal", id);


### PR DESCRIPTION
Let's try this again with new workflow.